### PR TITLE
[AIR-1040] Add description to pyproject.toml

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,3 +3,4 @@ src/airtop/wrapper/windows_client.py
 src/airtop/wrapper/sessions_client.py
 src/airtop/client.py
 src/airtop/__init__.py
+pyproject.toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,18 @@
 [tool.poetry]
 name = "airtop"
-version = "0.0.22"
-description = ""
+version = "0.0.23"
+description = "SDK for Airtop cloud browsers"
 readme = "README.md"
 authors = []
-keywords = []
+keywords = [
+    "airtop",
+    "ai",
+    "cloud",
+    "browser",
+    "automation",
+    "agent",
+    "python",
+]
 license = "MIT"
 classifiers = [
     "Intended Audience :: Developers",


### PR DESCRIPTION
Ignore pyproject.toml in .fernignore

The description in pyproject.toml should be generated by Fern automatically, but there's an issue on fern that is avoiding that from happening, so we're manually updating the file, but to avoid fern to automatically overwrite our changes, we need to add the file to the fernignore file.