### PR TITLE
[AIR-1099] Update pyproject.toml generation

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -3,4 +3,3 @@ src/airtop/wrapper/windows_client.py
 src/airtop/wrapper/sessions_client.py
 src/airtop/client.py
 src/airtop/__init__.py
-pyproject.toml


### PR DESCRIPTION
This PR includes the following:

- Removes the pyproject.toml from fernignore so that it can be generated by fern.