### PR TITLE
default time threshold seconds

### DIFF
--- a/src/airtop/wrapper/windows_client.py
+++ b/src/airtop/wrapper/windows_client.py
@@ -271,6 +271,10 @@ class AirtopWindows(WindowsClient):
             request_options = RequestOptions(timeout_in_seconds=600)
         elif request_options.get("timeout_in_seconds") is None:
             request_options.update({"timeout_in_seconds": 600})
+
+        if time_threshold_seconds is None:
+            time_threshold_seconds = 300
+            
         return super().scrape_content(session_id, window_id, client_request_id=client_request_id, cost_threshold_credits=cost_threshold_credits, time_threshold_seconds=time_threshold_seconds, request_options=request_options)
 
     def summarize_content(


### PR DESCRIPTION
Without this default, we end up with `request body is required` errors when we call `scrape_content` with only a session id and window id.  This is because all the omitted config values get filtered out and we end up with no request body for the POST request.

To reproduce the issue on the current SDK, call:

```python
response = client.windows.scrape_content(session_id=session_id window_id=window_id) # no additional options
```