### PR TITLE
Link to ci workflow in slack message, instead of itself

### DIFF
--- a/.github/workflows/notify-failure.yml
+++ b/.github/workflows/notify-failure.yml
@@ -5,7 +5,6 @@ on:
     workflows: ["ci"]
     types:
       - completed
-  workflow_dispatch: {}
 
 jobs:
   notify:
@@ -40,7 +39,7 @@ jobs:
                           "text": "Python SDK CI"
                       },
                       "style": "primary",
-                      "url": `https://github.com/airtop-ai/airtop-python-sdk/actions/runs/${{ github.run_id }}`
+                      "url": `https://github.com/airtop-ai/airtop-python-sdk/actions/workflows/ci.yml`
                     }
                   ]
                 }


### PR DESCRIPTION
and remove manual dispatch that was for testing