### PR TITLE
Update repo to be able to publish beta versions

### DIFF
--- a/.fernignore
+++ b/.fernignore
@@ -5,3 +5,4 @@ src/airtop/client.py
 src/airtop/__init__.py
 src/airtop/utils/
 .github/workflows/notify-failure.yml
+.github/workflows/ci.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   publish:
     needs: [compile, test]
-    if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
+    if: github.event_name == 'push' && (contains(github.ref, 'refs/tags/') || github.ref == 'refs/heads/beta' || github.ref == 'refs/heads/alpha')
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Update .fernignore to avoid updating ci.yml
Update ci.yml to publish a new version on beta or alpha brances.

> Node sdk similar PR: https://github.com/airtop-ai/airtop-node-sdk/pull/50