### PR TITLE
ci - tag python

### DIFF
--- a/.github/workflows/beta-tag.yml
+++ b/.github/workflows/beta-tag.yml
@@ -13,10 +13,14 @@ jobs:
           ssh-key: "${{secrets.COMMIT_KEY}}"
           ref: beta
 
+      - name: Install tomli
+        run: |
+          python -m pip install tomli
+
       - name: tag
         run: |
-          AIRTOP_VERSION=$(jq -r .version package.json)
+          AIRTOP_VERSION=$(print(tomli.load(open('pyproject.toml', mode='rb'))['tool']['poetry']['version']))
           echo "AIRTOP_VERSION: $AIRTOP_VERSION"
-          git tag "$AIRTOP_VERSION" 
-          git push origin "$AIRTOP_VERSION"
-          gh release create "$AIRTOP_VERSION" --prerelease --latest=false --target beta --notes "Beta release $AIRTOP_VERSION" -t "$AIRTOP_VERSION"
+          # git tag "$AIRTOP_VERSION" 
+          # git push origin "$AIRTOP_VERSION"
+          # gh release create "$AIRTOP_VERSION" --prerelease --latest=false --target beta --notes "Beta release $AIRTOP_VERSION" -t "$AIRTOP_VERSION"

--- a/.github/workflows/beta-tag.yml
+++ b/.github/workflows/beta-tag.yml
@@ -21,6 +21,6 @@ jobs:
         run: |
           AIRTOP_VERSION=$(python -c "import tomli; print(tomli.load(open('pyproject.toml', mode='rb'))['tool']['poetry']['version'])")
           echo "AIRTOP_VERSION: $AIRTOP_VERSION"
-          # git tag "$AIRTOP_VERSION" 
-          # git push origin "$AIRTOP_VERSION"
-          # gh release create "$AIRTOP_VERSION" --prerelease --latest=false --target beta --notes "Beta release $AIRTOP_VERSION" -t "$AIRTOP_VERSION"
+          git tag "$AIRTOP_VERSION" 
+          git push origin "$AIRTOP_VERSION"
+          gh release create "$AIRTOP_VERSION" --prerelease --latest=false --target beta --notes "Beta release $AIRTOP_VERSION" -t "$AIRTOP_VERSION"

--- a/.github/workflows/beta-tag.yml
+++ b/.github/workflows/beta-tag.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: tag
         run: |
-          AIRTOP_VERSION=$(print(tomli.load(open('pyproject.toml', mode='rb'))['tool']['poetry']['version']))
+          AIRTOP_VERSION=$(python -c "import tomli; print(tomli.load(open('pyproject.toml', mode='rb'))['tool']['poetry']['version'])")
           echo "AIRTOP_VERSION: $AIRTOP_VERSION"
           # git tag "$AIRTOP_VERSION" 
           # git push origin "$AIRTOP_VERSION"


### PR DESCRIPTION
This will parse pyproject.toml to grab the version, similar to what's working in the node workflow.  And assuming python is installed and then can install the tomli package.

After verifying, I will follow up and uncomment the tag and release steps.

This run shows it working: https://github.com/airtop-ai/airtop-python-sdk/actions/runs/13956858551/job/39070009602